### PR TITLE
Update pep8_integration.py to use new names for pep8 package

### DIFF
--- a/share/plug-ins/pep8_integration.py
+++ b/share/plug-ins/pep8_integration.py
@@ -1,12 +1,12 @@
 """
 This is the python format checker plugin for GPS.
-Its aim is to check identatoin, style when:
+Its aim is to check indentation, style when:
  1 user stop editing
  2 before python script is saved
 """
 
 import sys
-import pep8
+import pycodestyle
 import GPS
 import colorschemes
 from cStringIO import StringIO
@@ -29,7 +29,7 @@ class Pep8_Module(Module):
 
     def __format_check(self, file):
         """
-           Check format using pep8 for python source codes
+           Check format using pycodestyle for python source codes
         """
         # only check python file
         if file.language() == "python":
@@ -51,7 +51,7 @@ class Pep8_Module(Module):
                 source = [i + "\n" for i in s.splitlines()]
 
             with Catch_Stdout() as output:
-                m = pep8.Checker(filename=None, lines=source, report=False)
+                m = pycodestyle.Checker(filename=None, lines=source, report=False)
                 m.check_all()
 
             for i in output:


### PR DESCRIPTION
As PEP8 has renamed to [pycodestyle](https://pypi.python.org/pypi/pycodestyle/2.3.1)

Running GPS (compiled with FSF GCC, not from the binary GPL released version) in newer system causing warning message being printed.