### PR TITLE
Workaround to fix the Command / Apple modifier key functionality on Darwin / macOS.

### DIFF
--- a/common/ui/src/darwin_extras.adb
+++ b/common/ui/src/darwin_extras.adb
@@ -1,0 +1,21 @@
+with Config;
+with Gtk.Accel_Group;
+
+package body Darwin_Extras is
+
+   --------------------------
+   -- Get_Default_Mod_Mask --
+   --------------------------
+
+   function Get_Default_Mod_Mask return Gdk_Modifier_Type is
+   --  macOS (at least 12.0) fires MOD2 and META modifiers
+   --  as we want only META we suppress MOD2 to the default mask
+   begin
+      if Config.Darwin_Target then
+         return Gtk.Accel_Group.Get_Default_Mod_Mask and not Mod2_Mask;
+      else
+         return Gtk.Accel_Group.Get_Default_Mod_Mask;
+      end if;
+   end Get_Default_Mod_Mask;
+
+end Darwin_Extras;

--- a/common/ui/src/darwin_extras.ads
+++ b/common/ui/src/darwin_extras.ads
@@ -1,0 +1,9 @@
+with Gdk.Types; use Gdk.Types;
+
+--  Patch adapatation for macOS (at least 12.0)
+
+package Darwin_Extras is
+
+   function Get_Default_Mod_Mask return Gdk_Modifier_Type;
+
+end Darwin_Extras;

--- a/kernel/src/interactive_consoles.adb
+++ b/kernel/src/interactive_consoles.adb
@@ -81,6 +81,8 @@ with GPS.Kernel.Modules.UI;    use GPS.Kernel.Modules.UI;
 with GPS.Kernel.Scripts;       use GPS.Kernel.Scripts;
 with GPS.Kernel.Style_Manager; use GPS.Kernel.Style_Manager;
 
+with Darwin_Extras;
+
 package body Interactive_Consoles is
 
    Me : constant Trace_Handle := Create ("GPS.KERNEL.INTERACTIVE_CONSOLE");
@@ -1152,7 +1154,8 @@ package body Interactive_Consoles is
    begin
       if Console.On_Key /= null then
          if Console.On_Key (Console   => Console,
-                            Modifier  => Get_State (Event),
+                            Modifier  => Get_State (Event) and
+                              Darwin_Extras.Get_Default_Mod_Mask,
                             Key       => Key,
                             Uni       => To_Unicode (Key),
                             User_Data => Console.Key_User_Data)

--- a/keymanager/src/command_window.adb
+++ b/keymanager/src/command_window.adb
@@ -29,7 +29,6 @@ with Glib;                    use Glib;
 with Glib.Object;             use Glib.Object;
 with Gtkada.Handlers;         use Gtkada.Handlers;
 with Gtkada.MDI;              use Gtkada.MDI;
-with Gtk.Accel_Group;         use Gtk.Accel_Group;
 with Gtk.Box;                 use Gtk.Box;
 with Gtk.Enums;               use Gtk.Enums;
 with Gtk.Label;               use Gtk.Label;
@@ -48,6 +47,8 @@ with GPS.Kernel.Scripts;      use GPS.Kernel.Scripts;
 with GPS.Kernel;              use GPS.Kernel;
 with GUI_Utils;               use GUI_Utils;
 with KeyManager_Module;       use KeyManager_Module;
+
+with Darwin_Extras;
 
 package body Command_Window is
    Me : constant Trace_Handle := Create ("GPS.KEY_MANAGER.COMMAND");
@@ -189,7 +190,7 @@ package body Command_Window is
       Key    : constant Gdk_Key_Type := Get_Key_Val (Event);
       Button : constant Guint := Get_Button (Event);
       Modif  : constant Gdk_Modifier_Type :=
-                Get_State (Event) and Get_Default_Mod_Mask;
+                Get_State (Event) and Darwin_Extras.Get_Default_Mod_Mask;
    begin
       --  Ignore when the key is just one of the modifier. No binding can
       --  be associated to them anyway, so this is slightly more efficient,

--- a/keymanager/src/keymanager_module-gui.adb
+++ b/keymanager/src/keymanager_module-gui.adb
@@ -97,6 +97,8 @@ with Histories;                use Histories;
 with GPS.Dialogs;              use GPS.Dialogs;
 with Filter_Panels;            use Filter_Panels;
 
+with Darwin_Extras;
+
 package body KeyManager_Module.GUI is
 
    Me : constant Trace_Handle := Create ("GPS.KEY_MANAGER.KEYMGR_GUI");
@@ -949,7 +951,8 @@ package body KeyManager_Module.GUI is
       if Text /= Special_Key_Binding then
          Output.Key    := Get_Key_Val (Event);
          Output.Button := 0;
-         Output.State  := Get_State (Event) and Get_Default_Mod_Mask;
+         Output.State  := Get_State (Event) and
+           Darwin_Extras.Get_Default_Mod_Mask;
          Main_Quit;
       end if;
       return True;
@@ -976,7 +979,8 @@ package body KeyManager_Module.GUI is
       if Text /= Special_Key_Binding then
          Output.Key    := 0;
          Output.Button := Get_Button (Event);
-         Output.State  := Get_State (Event) and Get_Default_Mod_Mask;
+         Output.State  := Get_State (Event) and
+           Darwin_Extras.Get_Default_Mod_Mask;
          Main_Quit;
       end if;
       return True;

--- a/keymanager/src/keymanager_module.adb
+++ b/keymanager/src/keymanager_module.adb
@@ -30,7 +30,7 @@ with Gdk.Types;                      use Gdk.Types;
 with Gdk.Window;                     use Gdk.Window;
 with Glib.Convert;                   use Glib.Convert;
 with Glib;                           use Glib;
-with Gtk.Accel_Group;                use Gtk.Accel_Group;
+with Gtk.Accel_Group;
 with Gtk.Main;
 with Gtk.Widget;                     use Gtk.Widget;
 with Gtk.Window;                     use Gtk.Window;
@@ -57,6 +57,8 @@ with KeyManager_Module.GUI;
 with System.Assertions;              use System.Assertions;
 with XML_Parsers;
 with XML_Utils;                      use XML_Utils;
+
+with Darwin_Extras;
 
 package body KeyManager_Module is
 
@@ -1079,7 +1081,7 @@ package body KeyManager_Module is
       end if;
 
       --  Remove any num-lock and caps-lock modifiers
-      Modifier := State and Get_Default_Mod_Mask;
+      Modifier := State and Darwin_Extras.Get_Default_Mod_Mask;
 
       --  If Caps lock in on, and the key is an upper-case character,
       --  lower-case it.

--- a/share/support/ui/pygps/__init__.py
+++ b/share/support/ui/pygps/__init__.py
@@ -396,7 +396,7 @@ try:
     # it is better to directly call the appropriate GPS action or menu
     # rather than rely on these functions
 
-    if "linux" in sys.platform:
+    if "linux" in sys.platform or sys.platform == "darwin":
         GDK_BACKSPACE = 65288
         GDK_TAB = 65289
         GDK_RETURN = Gdk.KEY_Return
@@ -440,7 +440,7 @@ try:
            passes the event to the key manager, but synthesize the event
            in Python directly.
         """
-        if not bypass_keymanager:
+        if not bypass_keymanager or sys.platform == "darwin":
             keycode = 0
 
             # Try to retrieve the hardware keycode with the appropriate
@@ -479,7 +479,7 @@ try:
                 keyboard.press(key)
                 keyboard.release(key)
 
-        if process_events:
+        if process_events or sys.platform == "darwin":
             process_all_events()
 
     def get_notebook(widget):

--- a/src_editor/src/src_editor_view.adb
+++ b/src_editor/src/src_editor_view.adb
@@ -39,7 +39,6 @@ with Glib.Object;                use Glib.Object;
 with Glib.Values;                use Glib.Values;
 
 with Gtk;                        use Gtk;
-with Gtk.Accel_Group;
 with Gtk.Adjustment;             use Gtk.Adjustment;
 with Gtk.Drawing_Area;           use Gtk.Drawing_Area;
 with Gtk.Enums;                  use Gtk.Enums;
@@ -97,6 +96,8 @@ with Gtkada.Types;               use Gtkada.Types;
 
 with GUI_Utils;                  use GUI_Utils;
 with String_Utils;               use String_Utils;
+
+with Darwin_Extras;
 
 --  Drawing the side info is organized this way:
 --
@@ -2641,7 +2642,7 @@ package body Src_Editor_View is
       --  when the user scrolls while pressing the primary key
       --  (e.g: Ctrl on Linux, Cmd on Mac)
 
-      if (Get_State (Event) and Gtk.Accel_Group.Get_Default_Mod_Mask) =
+      if (Get_State (Event) and Darwin_Extras.Get_Default_Mod_Mask) =
         View.Get_Modifier_Mask (Primary_Accelerator)
       then
          Get_Scroll_Direction (Event, Direction);

--- a/vsearch/src/vsearch.adb
+++ b/vsearch/src/vsearch.adb
@@ -91,6 +91,8 @@ with Histories;                 use Histories;
 with Projects;                  use Projects;
 with XML_Utils;                 use XML_Utils;
 
+with Darwin_Extras;
+
 package body Vsearch is
    Me : constant Trace_Handle := Create ("GPS.OTHERS.VSEARCH_MODULE");
 
@@ -1738,7 +1740,8 @@ package body Vsearch is
                                    (Vsearch_Module_Id.Context));
       In_Incremental_Mode : constant Boolean := Is_In_Incremental_Mode;
       Key                 : constant Gdk_Key_Type := Get_Key_Val (Event);
-      Mods                : constant Gdk_Modifier_Type := Get_State (Event);
+      Mods                : constant Gdk_Modifier_Type := Get_State (Event) and
+        Darwin_Extras.Get_Default_Mod_Mask;
    begin
       if Key = GDK_Return or else Key = GDK_KP_Enter then
 


### PR DESCRIPTION
   --  macOS (at least 12.0) fires MOD2 and META key modifiers
   --  as we want only META we suppress MOD2 to the default mask
Honestly, I wasn't able to determine where is the root cause: either macOS, GTK or GTKAda. Thus the workaround is applied at GNATStudio level.